### PR TITLE
Add M3 production field

### DIFF
--- a/data/proizvodnja.csv
+++ b/data/proizvodnja.csv
@@ -1,2 +1,2 @@
-﻿datum;brojZahteva;artikal;m1;m2;napomena
-4.9.2025;1;30xslobodnox2;;96;"Otvori Izmeni"
+datum;brojZahteva;artikal;m1;m2;m3;napomena
+4.9.2025;1;30xslobodnox2;;96;;"Otvori Izmeni"

--- a/dnevna-proizvodnja.html
+++ b/dnevna-proizvodnja.html
@@ -270,7 +270,27 @@
 </div>
 <div class="row">
 <div>
-<div class="artikal-m-row">  <div class="field">    <label for="artikal">Artikal (iz Excela)</label>    <div class="ac2-wrap"><input type="text" id="artikal" name="artikal" placeholder="Počni da kucaš...">    <div id="acArtikal"></div></div>  </div>  <div class="field">    <label for="m2">Proizvedeno (M²)</label>    <input type="number" step="any" id="m2" name="m2" placeholder="npr. 123.45">  </div>  <div class="field">    <label for="m1">Proizvedeno (M¹)</label>    <input type="number" step="any" id="m1" name="m1" placeholder="npr. 123.45">  </div></div></div></div></div>
+<div class="artikal-m-row">
+  <div class="field">
+    <label for="artikal">Artikal (iz Excela)</label>
+    <div class="ac2-wrap">
+      <input type="text" id="artikal" name="artikal" placeholder="Počni da kucaš...">
+      <div id="acArtikal"></div>
+    </div>
+  </div>
+  <div class="field">
+    <label for="m2">Proizvedeno (M²)</label>
+    <input type="number" step="any" id="m2" name="m2" placeholder="npr. 123.45">
+  </div>
+  <div class="field">
+    <label for="m1">Proizvedeno (M¹)</label>
+    <input type="number" step="any" id="m1" name="m1" placeholder="npr. 123.45">
+  </div>
+  <div class="field">
+    <label for="m3">Proizvedeno (M³)</label>
+    <input type="number" step="any" id="m3" name="m3" placeholder="npr. 123.45">
+  </div>
+</div></div></div></div>
 </div>
 <div>
 
@@ -296,6 +316,7 @@
           <th>Artikal</th>
           <th>M¹</th>
           <th>M²</th>
+          <th>M³</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -322,8 +343,8 @@
 <th>Datum</th>
 <th>Broj zahteva</th>
 <th>Artikal</th>
-<th>m¹</th><th>M²</th>
-<th></th><th class="right nowrap">Akcije</th></tr>
+<th>m¹</th><th>M²</th><th>M³</th>
+<th>Napomena</th><th class="right nowrap">Akcije</th></tr>
 </thead>
 <tbody></tbody>
 </table>
@@ -401,6 +422,7 @@ function renderTable() {
       + '<td>' + (row.artikal || '') + '</td>'
       + '<td>' + (row.m1 != null ? Number(row.m1).toFixed(2) : '') + '</td>'
       + '<td>' + (row.m2 != null ? Number(row.m2).toFixed(2) : '') + '</td>'
+      + '<td>' + (row.m3 != null ? Number(row.m3).toFixed(2) : '') + '</td>'
       + '<td class="actions">'
       +   '<button data-action="edit" data-i="' + idx + '">Izmeni</button> '
       +   '<button data-action="del" data-i="' + idx + '" class="secondary">Obriši</button>'
@@ -417,7 +439,7 @@ function resetForm() {
 
 function exportCSV() {
   const rows = loadReports();
-  const headers = ['datum','brojZahteva','artikal','m1','m2'];
+  const headers = ['datum','brojZahteva','artikal','m1','m2','m3'];
   const csv = [headers.join(',')]
     .concat(rows.map(r => headers.map(h => {
       const v = (r[h] ?? '').toString().replaceAll('"','""');
@@ -450,12 +472,13 @@ document.getElementById('form-izvestaj').addEventListener('submit', (e) => {
   const artikal = document.getElementById('artikal').value.trim();
   const m1 = parseFloat(document.getElementById('m1').value);
   const m2 = parseFloat(document.getElementById('m2').value);
+  const m3 = parseFloat(document.getElementById('m3').value);
   if (!datum || !brojZahteva || !artikal || isNaN(m1)) {
     alert('Popunite sva polja.');
     return;
   }
   const rows = loadReports();
-  rows.push({ datum, brojZahteva, artikal, m1: isNaN(m1) ? null : m1, m2: isNaN(m2) ? null : m2 });
+  rows.push({ datum, brojZahteva, artikal, m1: isNaN(m1) ? null : m1, m2: isNaN(m2) ? null : m2, m3: isNaN(m3) ? null : m3 });
   saveReports(rows);
   renderTable();
   resetForm();
@@ -483,6 +506,7 @@ document.querySelector('#tabela').addEventListener('click', (e) => {
     document.getElementById('artikal').value = r.artikal || '';
     document.getElementById('m1').value = r.m1 != null ? r.m1 : '';
     document.getElementById('m2').value = r.m2 != null ? r.m2 : '';
+    document.getElementById('m3').value = r.m3 != null ? r.m3 : '';
     rows.splice(idx, 1);
     saveReports(rows);
     renderTable();
@@ -727,6 +751,7 @@ document.addEventListener("DOMContentLoaded", function(){
   <input type="hidden" name="artikal" />
   <input type="hidden" name="m1" />
   <input type="hidden" name="m2" />
+  <input type="hidden" name="m3" />
   <input type="hidden" name="napomena" />
 </form>
 <script>
@@ -748,6 +773,7 @@ document.addEventListener("DOMContentLoaded", function(){
         F.elements['artikal'].value = document.getElementById('artikal')?.value || '';
         F.elements['m1'].value = document.getElementById('m1')?.value || '';
         F.elements['m2'].value = document.getElementById('m2')?.value || '';
+        F.elements['m3'].value = document.getElementById('m3')?.value || '';
         const nEl = document.getElementById('napomena');
         F.elements['napomena'].value = nEl ? (nEl.value||'').trim() : '';
         F.submit();
@@ -777,6 +803,7 @@ document.addEventListener("DOMContentLoaded", function(){
         obj.artikal ? ('Artikal: '+obj.artikal) : null,
         (obj.m1 && !isNaN(obj.m1)) ? ('M¹: '+obj.m1) : null,
         (obj.m2 && !isNaN(obj.m2)) ? ('M²: '+obj.m2) : null,
+        (obj.m3 && !isNaN(obj.m3)) ? ('M³: '+obj.m3) : null,
         obj.napomena ? ('Napomena: '+obj.napomena) : null
       ].filter(Boolean).join(' • ');
       const el = document.getElementById('lastSaved');
@@ -816,6 +843,7 @@ document.addEventListener("DOMContentLoaded", function(){
         <td>${obj.artikal||''}</td>
         <td>${fmt(obj.m1)||''}</td>
         <td>${fmt(obj.m2)||''}</td>
+        <td>${fmt(obj.m3)||''}</td>
       </tr>`;
       const tbody = document.querySelector('#lastTable tbody');
       if(tbody){ tbody.innerHTML = rowHtml; }
@@ -867,6 +895,7 @@ async function loadLastFromCSV(){
       + '<td>'+(last[idx('artikal')]||'')+'</td>'
       + '<td>'+(fmt(last[idx('m1')])||'')+'</td>'
       + '<td>'+(fmt(last[idx('m2')])||'')+'</td>'
+      + '<td>'+(fmt(last[idx('m3')])||'')+'</td>'
       + '</tr>';
     tbody.innerHTML = rowHtml;
   }catch(e){}
@@ -888,7 +917,9 @@ async function fetchCSVAll(){
       brojZahteva: cols[header.indexOf('brojZahteva')]||'',
       artikal: cols[header.indexOf('artikal')]||'',
       m1: cols[header.indexOf('m1')]||'',
-      m2: cols[header.indexOf('m2')]||''
+      m2: cols[header.indexOf('m2')]||'',
+      m3: cols[header.indexOf('m3')]||'',
+      napomena: cols[header.indexOf('napomena')]||''
     });
   }
   return rows;
@@ -916,6 +947,8 @@ async function renderPregledCSV(){
         + '<td>'+(r.artikal||'')+'</td>'
         + '<td>'+(fmt(r.m1)||'')+'</td>'
         + '<td>'+(fmt(r.m2)||'')+'</td>'
+        + '<td>'+(fmt(r.m3)||'')+'</td>'
+        + '<td>'+(r.napomena||'')+'</td>'
         + '<td class="right"><button class="secondary otvori" type="button" style="width:auto">Otvori</button> <button class="ok edit-btn" type="button" style="width:auto;margin-left:6px">Izmeni</button></td>';
       tbody.appendChild(tr);
     });
@@ -967,8 +1000,9 @@ async function renderPregledCSV(){
       <div class="col-4"><label>Datum</label><input id="editDatum"/></div>
       <div class="col-4"><label>Broj zahteva</label><input id="editBroj"/></div>
       <div class="col-4"><label>Artikal</label><input id="editArtikal"/></div>
-      <div class="col-6"><label>M¹</label><input id="editM1" type="number" step="any"/></div>
-      <div class="col-6"><label>M²</label><input id="editM2" type="number" step="any"/></div>
+      <div class="col-4"><label>M¹</label><input id="editM1" type="number" step="any"/></div>
+      <div class="col-4"><label>M²</label><input id="editM2" type="number" step="any"/></div>
+      <div class="col-4"><label>M³</label><input id="editM3" type="number" step="any"/></div>
       <div class="col-12"><label>Napomena</label><input id="editNapomena"/></div>
     </div>
   </div>
@@ -987,11 +1021,11 @@ async function renderPregledCSV(){
     }
     if(!btn) return;
     const tr = btn.closest('tr'); if(!tr) return;
-    const d = txt(tr,0), b = txt(tr,1), a = txt(tr,2), m1 = txt(tr,3), m2 = txt(tr,4), nap = txt(tr,5) || '';
+    const d = txt(tr,0), b = txt(tr,1), a = txt(tr,2), m1 = txt(tr,3), m2 = txt(tr,4), m3 = txt(tr,5), nap = txt(tr,6) || '';
     const back = document.getElementById('modalBackProd'); if(!back) return;
     const chip = document.getElementById('chipKeyProd'); if(chip) chip.textContent = d+' • '+b+' • '+a;
     const set = (id,val)=>{ const el=document.getElementById(id); if(el) el.value=val; };
-    set('editDatum', d); set('editBroj', b); set('editArtikal', a); set('editM1', m1); set('editM2', m2); set('editNapomena', nap);
+    set('editDatum', d); set('editBroj', b); set('editArtikal', a); set('editM1', m1); set('editM2', m2); set('editM3', m3); set('editNapomena', nap);
     back.style.display = 'flex';
   }, true);
 
@@ -1041,6 +1075,7 @@ async function renderPregledCSV(){
         artikal:     (document.getElementById('editArtikal')||{}).value?.trim() || '',
         m1:          (document.getElementById('editM1')||{}).value?.trim() || '',
         m2:          (document.getElementById('editM2')||{}).value?.trim() || '',
+        m3:          (document.getElementById('editM3')||{}).value?.trim() || '',
         napomena:    (document.getElementById('editNapomena')||{}).value?.trim() || '',
         o_datum:       sb.dataset.odatum || '',
         o_brojZahteva: sb.dataset.obroj  || '',
@@ -1067,7 +1102,8 @@ async function renderPregledCSV(){
           if(tr.children[2]) tr.children[2].textContent = payload.artikal;
           if(tr.children[3]) tr.children[3].textContent = payload.m1;
           if(tr.children[4]) tr.children[4].textContent = payload.m2;
-          if(tr.children[5]) tr.children[5].textContent = payload.napomena;
+          if(tr.children[5]) tr.children[5].textContent = payload.m3;
+          if(tr.children[6]) tr.children[6].textContent = payload.napomena;
           break;
         }
       }

--- a/save_izvestaj.php
+++ b/save_izvestaj.php
@@ -37,6 +37,7 @@ $broj       = isset($_POST['brojZahteva']) ? trim((string)$_POST['brojZahteva'])
 $artikal    = isset($_POST['artikal']) ? trim((string)$_POST['artikal']) : '';
 $m1         = isset($_POST['m1']) ? trim((string)$_POST['m1']) : '';
 $m2         = isset($_POST['m2']) ? trim((string)$_POST['m2']) : '';
+$m3         = isset($_POST['m3']) ? trim((string)$_POST['m3']) : '';
 $napomena   = isset($_POST['napomena']) ? trim((string)$_POST['napomena']) : '';
 $vremeUnosa = date('c');
 
@@ -49,6 +50,7 @@ if ($datum==='' || $broj==='' || $artikal==='') {
 
 $m1 = str_replace(',', '.', $m1);
 $m2 = str_replace(',', '.', $m2);
+$m3 = str_replace(',', '.', $m3);
 
 $needHeader = !file_exists($csv) || filesize($csv)===0;
 
@@ -68,12 +70,12 @@ if (!@flock($h, LOCK_EX)) {
 }
 
 if ($needHeader){
-  if (@fputcsv($h, ['datum','brojZahteva','artikal','m1','m2','napomena','vremeUnosa'], ';')===false){
+  if (@fputcsv($h, ['datum','brojZahteva','artikal','m1','m2','m3','napomena','vremeUnosa'], ';')===false){
     elog("HEADER_WRITE_FAIL");
   }
 }
 
-$row = [$datum, $broj, $artikal, $m1, $m2, $napomena, $vremeUnosa];
+$row = [$datum, $broj, $artikal, $m1, $m2, $m3, $napomena, $vremeUnosa];
 if (@fputcsv($h, $row, ';')===false){
   elog("ROW_WRITE_FAIL datum=$datum broj=$broj");
   http_response_code(500);


### PR DESCRIPTION
## Summary
- add M³ production input and display
- wire M³ field into client storage, export, and CSV
- extend server CSV writing for M³ values

## Testing
- `php -l save_izvestaj.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba00b8e6e08327a5d668899e926667