### PR TITLE
Improve mobile layout on index and daily production pages

### DIFF
--- a/dnevna-proizvodnja.html
+++ b/dnevna-proizvodnja.html
@@ -64,7 +64,7 @@
       border-bottom:1px solid rgba(255,255,255,.08);
       box-shadow: 0 10px 30px rgba(0,0,0,.25);
     }
-    .h-wrap{max-width:1280px;margin:0 auto;padding:14px 22px;display:flex;gap:14px;align-items:center;justify-content:space-between}
+    .h-wrap{max-width:1280px;margin:0 auto;padding:14px 22px;display:flex;gap:14px;align-items:center;justify-content:space-between;flex-wrap:wrap}
     .brand{font-weight:900; letter-spacing:.4px; display:flex; align-items:center; gap:10px}
     .brand .sig{font-size:12px; color:var(--muted); letter-spacing:.28em}
     .neon{background: linear-gradient(135deg, var(--neon), var(--neon2));
@@ -80,6 +80,12 @@
     .wrap{max-width:1280px;margin:0 auto;padding:20px; position:relative; z-index:1}
     .deck{display:grid; grid-template-columns:repeat(12,1fr); gap:12px; margin-top:12px}
     .col-3{grid-column:span 3}.col-4{grid-column:span 4}.col-5{grid-column:span 5}.col-6{grid-column:span 6}.col-7{grid-column:span 7}.col-8{grid-column:span 8}.col-12{grid-column:span 12}
+    @media (max-width:768px){
+      .h-wrap{flex-direction:column;align-items:flex-start;gap:8px}
+      .wrap{padding:10px}
+      .deck{grid-template-columns:1fr}
+      .col-3,.col-4,.col-5,.col-6,.col-7,.col-8,.col-12{grid-column:span 1}
+    }
 
     .card{
       background: var(--glass);
@@ -120,6 +126,7 @@
     tbody tr:hover{ background:rgba(6,182,212,.08) }
     .right{text-align:right}
     .nowrap{white-space:nowrap}
+    .table-scroll{overflow-x:auto}
 
     /* STATS */
     .stat{ background: var(--glass-strong); border:1px solid var(--line); border-radius:16px; padding:14px; }
@@ -280,18 +287,20 @@
   <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
     <h2 style="margin:0;">Poslednji uneti izveštaj</h2>
   </div>
-  <table id="lastTable">
-    <thead>
-      <tr>
-        <th>Datum</th>
-        <th>Broj zahteva</th>
-        <th>Artikal</th>
-        <th>M¹</th>
-        <th>M²</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  <div class="table-scroll">
+    <table id="lastTable">
+      <thead>
+        <tr>
+          <th>Datum</th>
+          <th>Broj zahteva</th>
+          <th>Artikal</th>
+          <th>M¹</th>
+          <th>M²</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
 </div>
 
 </div><!-- end sekcija-unos -->
@@ -306,6 +315,7 @@
 <button class="secondary" id="exportJson">Izvezi JSON</button>
 </div>
 </div>
+<div class="table-scroll">
 <table id="tabela">
 <thead>
 <tr>
@@ -317,6 +327,7 @@
 </thead>
 <tbody></tbody>
 </table>
+</div>
 </div>
 </div><!-- end sekcija-pregled -->
 </main>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       border-bottom:1px solid rgba(255,255,255,.08);
       box-shadow: 0 10px 30px rgba(0,0,0,.25);
     }
-    .h-wrap{max-width:1280px;margin:0 auto;padding:14px 22px;display:flex;gap:14px;align-items:center;justify-content:space-between}
+    .h-wrap{max-width:1280px;margin:0 auto;padding:14px 22px;display:flex;gap:14px;align-items:center;justify-content:space-between;flex-wrap:wrap}
     .brand{font-weight:900; letter-spacing:.4px; display:flex; align-items:center; gap:10px}
     .brand .sig{font-size:12px; color:var(--muted); letter-spacing:.28em}
     .neon{background: linear-gradient(135deg, var(--neon), var(--neon2));
@@ -78,6 +78,12 @@
     .wrap{max-width:1280px;margin:0 auto;padding:20px; position:relative; z-index:1}
     .deck{display:grid; grid-template-columns:repeat(12,1fr); gap:12px; margin-top:12px}
     .col-3{grid-column:span 3}.col-4{grid-column:span 4}.col-5{grid-column:span 5}.col-6{grid-column:span 6}.col-7{grid-column:span 7}.col-8{grid-column:span 8}.col-12{grid-column:span 12}
+    @media (max-width:768px){
+      .h-wrap{flex-direction:column;align-items:flex-start;gap:8px}
+      .wrap{padding:10px}
+      .deck{grid-template-columns:1fr}
+      .col-3,.col-4,.col-5,.col-6,.col-7,.col-8,.col-12{grid-column:span 1}
+    }
 
     .card{
       background: var(--glass);
@@ -118,6 +124,7 @@
     tbody tr:hover{ background:rgba(6,182,212,.08) }
     .right{text-align:right}
     .nowrap{white-space:nowrap}
+    .table-scroll{overflow-x:auto}
 
     /* STATS */
     .stat{ background: var(--glass-strong); border:1px solid var(--line); border-radius:16px; padding:14px; }
@@ -252,6 +259,7 @@
 <div style="height:10px"></div>
 <div class="separator"></div>
 <h3 style="margin:6px 0 10px 0">Stavke zahteva</h3>
+<div class="table-scroll">
 <table id="stavkeTable">
 <thead><tr>
 <th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">Količina</th><th class="right">M¹</th><th>Napomena</th><th class="right"></th>
@@ -261,6 +269,7 @@
 <tr><th class="right" colspan="3">Ukupno stavki:</th><th class="right" id="ukupnoCell">0</th><th></th><th></th><th></th></tr>
 </tfoot>
 </table>
+</div>
 <div class="row" style="margin-top:12px">
 <button class="primary" id="sacuvajNalog" style="width:auto">💾 Sačuvaj nalog (Ctrl+S)</button>
 <button class="secondary" id="ocisti" style="width:auto">🧹 Očisti formu</button>
@@ -280,6 +289,7 @@
 </div>
 </div>
 <div style="height:10px"></div>
+<div class="table-scroll">
 <table id="pregledTable">
 <thead>
 <tr>
@@ -293,6 +303,7 @@
 </thead>
 <tbody></tbody>
 </table>
+</div>
 </div>
 </div>
 </div>
@@ -311,10 +322,12 @@
 <span class="pill">Adresa: <b id="detAdresa"></b></span>
 <span class="pill">Kreirano: <b id="detVreme"></b></span>
 </div>
+<div class="table-scroll">
 <table id="detTabela">
 <thead><tr><th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">Količina</th><th class="right">M¹</th><th>Napomena</th></tr></thead>
 <tbody></tbody>
 </table>
+</div>
 </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Add flex wrapping to header container and responsive grid for small screens
- Wrap "Stavke zahteva" table in a scrollable container to prevent horizontal overflow on mobile
- Apply same responsive header and table scrolling to dnevna-proizvodnja
- Wrap overview tables in scrollable containers so pregled content fits on small screens

## Testing
- `php -l index.html`
- `php -l dnevna-proizvodnja.html`


------
https://chatgpt.com/codex/tasks/task_e_68b9f99e15888327be6212465bf042c1