### PR TITLE
Prikaz artikala u preglednoj tabeli

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,7 @@
 <th data-sort="firma">Firma ⬍</th>
 <th data-sort="adresa">Adresa ⬍</th>
 <th class="nowrap" data-sort="vreme">Kreirano ⬍</th>
+<th>Artikli</th>
 <th class="right nowrap"># stavki</th>
 <th class="right nowrap">Akcije</th>
 </tr>
@@ -577,7 +578,7 @@ function renderPregled(){
     const iFirma  = idx('firma');
     const iAdresa = idx('adresa');
     const iVreme  = idx('vreme');
-    const iStavke = idx('stavke');
+    const iStavke = (idx('stavke_json') >= 0) ? idx('stavke_json') : idx('stavke');
 
     const orders = rows.slice(1).map(cols=>{
       let stavke=[];
@@ -598,11 +599,13 @@ function renderPregled(){
     filtered.forEach(n=>{
       const tr = document.createElement('tr');
       const dt = n.vreme ? new Date(n.vreme) : null;
+      const stavkeTxt = (n.stavke||[]).map(s=> (s.sifra||'') + ' (' + (s.kolicina||'') + ')').join('<br>');
       tr.innerHTML = '\
         <td class="nowrap"><b>'+ (n.broj||'') +'</b></td>\
         <td>'+ (n.firma||'') +'</td>\
         <td>'+ (n.adresa||'') +'</td>\
         <td class="nowrap">'+ (dt ? dt.toLocaleString() : '') +'</td>\
+        <td>'+ stavkeTxt +'</td>\
         <td class="right">'+ ((n.stavke||[]).length) +'</td>\
         <td class="right"><button class="secondary" data-open="'+ (n.broj||'') +'" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>';
       tb.appendChild(tr);
@@ -620,11 +623,13 @@ function renderPregled(){
         filtered.sort(_sorter.current);
         filtered.forEach(n=>{
           const tr = document.createElement('tr');
+          const stavkeTxt = (n.stavke||[]).map(s=> (s.sifra||'') + ' (' + (s.kolicina||'') + ')').join('<br>');
           tr.innerHTML = '\
             <td class="nowrap"><b>'+ n.broj +'</b></td>\
             <td>'+ (n.firma||'') +'</td>\
             <td>'+ (n.adresa||'') +'</td>\
             <td class="nowrap">'+ new Date(n.vreme).toLocaleString() +'</td>\
+            <td>'+ stavkeTxt +'</td>\
             <td class="right">'+ ((n.stavke||[]).length) +'</td>\
             <td class="right"><button class="secondary" data-open="'+ n.broj +'" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>';
           tb.appendChild(tr);


### PR DESCRIPTION
## Summary
- Dodata kolona **Artikli** u pregled naloga radi prikaza sifara i kolicina
- Iscrtavanje stavki po nalogu iz CSV-a i lokalne kopije kao lista u tabeli
- Parsiranje `stavke_json` kolone obezbeđuje popunjavanje nove kolone artikala

## Testing
- `php -l index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba094612f883278fe3d416c963a6cb