### PR TITLE
Expand quantity inputs for orders

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,12 +77,12 @@
     /* LAYOUT */
     .wrap{max-width:1280px;margin:0 auto;padding:20px; position:relative; z-index:1}
     .deck{display:grid; grid-template-columns:repeat(12,1fr); gap:12px; margin-top:12px}
-    .col-3{grid-column:span 3}.col-4{grid-column:span 4}.col-5{grid-column:span 5}.col-6{grid-column:span 6}.col-7{grid-column:span 7}.col-8{grid-column:span 8}.col-12{grid-column:span 12}
+    .col-3{grid-column:span 3}.col-4{grid-column:span 4}.col-5{grid-column:span 5}.col-6{grid-column:span 6}.col-7{grid-column:span 7}.col-8{grid-column:span 8}.col-9{grid-column:span 9}.col-12{grid-column:span 12}
     @media (max-width:768px){
       .h-wrap{flex-direction:column;align-items:flex-start;gap:8px}
       .wrap{padding:10px}
       .deck{grid-template-columns:1fr}
-      .col-3,.col-4,.col-5,.col-6,.col-7,.col-8,.col-12{grid-column:span 1}
+      .col-3,.col-4,.col-5,.col-6,.col-7,.col-8,.col-9,.col-12{grid-column:span 1}
     }
 
     .card{
@@ -238,14 +238,22 @@
 <select id="artikalSelect" style="display:none"></select>
 </div>
 <div class="col-3">
-<label>Količina</label>
+<label>Količina (M²)</label>
 <input id="kolicina" step="0.001" type="number" value="1"/>
 </div>
 <div class="col-3">
-<label>Zahtev (M¹)</label>
+<label>Količina (M¹)</label>
 <input id="m1zahtev" step="0.001" type="number" placeholder="npr. 123.45"/>
 </div>
 <div class="col-3">
+<label>Količina (M³)</label>
+<input id="m3zahtev" step="0.001" type="number" placeholder="npr. 123.45"/>
+</div>
+<div class="col-3">
+<label>Količina (kom)</label>
+<input id="komzahtev" step="1" type="number" placeholder="npr. 5"/>
+</div>
+<div class="col-9">
 <label>Napomena (stavka)</label>
 <input id="napomena" placeholder="npr. polirati, paletirati…"/>
 </div>
@@ -262,11 +270,11 @@
 <div class="table-scroll">
 <table id="stavkeTable">
 <thead><tr>
-<th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">Količina</th><th class="right">M¹</th><th>Napomena</th><th class="right"></th>
+<th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">M²</th><th class="right">M¹</th><th class="right">M³</th><th class="right">Kom</th><th>Napomena</th><th class="right"></th>
 </tr></thead>
 <tbody></tbody>
 <tfoot>
-<tr><th class="right" colspan="3">Ukupno stavki:</th><th class="right" id="ukupnoCell">0</th><th></th><th></th><th></th></tr>
+<tr><th class="right" colspan="3">Ukupno stavki:</th><th class="right" id="ukupnoCell">0</th><th></th><th></th><th></th><th></th><th></th></tr>
 </tfoot>
 </table>
 </div>
@@ -325,7 +333,7 @@
 </div>
 <div class="table-scroll">
 <table id="detTabela">
-<thead><tr><th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">Količina</th><th class="right">M¹</th><th>Napomena</th></tr></thead>
+<thead><tr><th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">M²</th><th class="right">M¹</th><th class="right">M³</th><th class="right">Kom</th><th>Napomena</th></tr></thead>
 <tbody></tbody>
 </table>
 </div>
@@ -443,6 +451,8 @@
           <td>${s.jedinica}</td>
           <td class="right">${Number(s.kolicina).toFixed(3)}</td>
           <td class="right">${s.m1!=null?Number(s.m1).toFixed(2):''}</td>
+          <td class="right">${s.m3!=null?Number(s.m3).toFixed(3):''}</td>
+          <td class="right">${s.kom!=null?Number(s.kom).toFixed(0):''}</td>
           <td>${s.napomena||''}</td>
           <td class="right"><button class="danger" data-idx="${idx}" style="width:auto">Ukloni</button></td>`;
         tb.appendChild(tr);
@@ -459,14 +469,18 @@
         const sifra = q('#artikalSelect').value;
         const kolicina = q('#kolicina').value;
         const m1 = q('#m1zahtev').value;
+        const m3 = q('#m3zahtev').value;
+        const kom = q('#komzahtev').value;
         const napomena = q('#napomena').value.trim();
         const a = ARTIKLI.find(x=>x.sifra===sifra);
         if(!a){ notify('Odaberi artikal', true); return; }
         if(!kolicina || Number(kolicina)<=0){ notify('Unesi količinu', true); return; }
-        STAVKE.push({ ...a, kolicina:Number(kolicina), m1: m1 ? Number(m1) : null, napomena });
+        STAVKE.push({ ...a, kolicina:Number(kolicina), m1: m1 ? Number(m1) : null, m3: m3 ? Number(m3) : null, kom: kom ? Number(kom) : null, napomena });
         renderStavke();
         q('#napomena').value='';
         q('#m1zahtev').value='';
+        q('#m3zahtev').value='';
+        q('#komzahtev').value='';
       }
     });
 
@@ -490,7 +504,16 @@
       const nalog = {
         broj, firma, adresa,
         vreme: new Date().toISOString(),
-        stavke: STAVKE.map(s=>({sifra:s.sifra, dimenzije:s.dimenzije, jedinica:s.jedinica, kolicina:s.kolicina, m1:s.m1, napomena:s.napomena||''}))
+        stavke: STAVKE.map(s=>({
+          sifra:s.sifra,
+          dimenzije:s.dimenzije,
+          jedinica:s.jedinica,
+          kolicina:s.kolicina,
+          m1:s.m1,
+          m3:s.m3,
+          kom:s.kom,
+          napomena:s.napomena||''
+        }))
       };
       const orders = getOrders();
       orders.push(nalog);
@@ -671,7 +694,7 @@ function renderPregled(){
       const tb = q('#detTabela tbody'); tb.innerHTML='';
       nalog.stavke.forEach(s=>{
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${s.sifra}</td><td>${s.dimenzije}</td><td>${s.jedinica}</td><td class="right">${Number(s.kolicina).toFixed(3)}</td><td class="right">${s.m1!=null?Number(s.m1).toFixed(2):''}</td><td>${s.napomena||''}</td>`;
+        tr.innerHTML = `<td>${s.sifra}</td><td>${s.dimenzije}</td><td>${s.jedinica}</td><td class="right">${Number(s.kolicina).toFixed(3)}</td><td class="right">${s.m1!=null?Number(s.m1).toFixed(2):''}</td><td class="right">${s.m3!=null?Number(s.m3).toFixed(3):''}</td><td class="right">${s.kom!=null?Number(s.kom).toFixed(0):''}</td><td>${s.napomena||''}</td>`;
         tb.appendChild(tr);
       });
       q('#modalBack').style.display='flex';
@@ -1027,9 +1050,9 @@ function openEditModal(nalog){
     </div>
     <div class="table-scroll">
     <table id="detTabela">
-      <thead><tr><th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">Količina</th><th class="right">M¹</th><th>Napomena</th><th class="right"></th></tr></thead>
+      <thead><tr><th>Šifra</th><th>Dimenzije</th><th>JM</th><th class="right">M²</th><th class="right">M¹</th><th class="right">M³</th><th class="right">Kom</th><th>Napomena</th><th class="right"></th></tr></thead>
       <tbody></tbody>
-      <tfoot><tr><td colspan="7"><button class="ghost" id="addLine" style="width:auto">➕ Dodaj stavku</button></td></tr></tfoot>
+      <tfoot><tr><td colspan="9"><button class="ghost" id="addLine" style="width:auto">➕ Dodaj stavku</button></td></tr></tfoot>
     </table>
     </div>
   `;
@@ -1046,6 +1069,8 @@ function openEditModal(nalog){
         <td><input value="${s.jedinica||''}" data-k="jedinica" style="max-width:80px"/></td>
         <td class="right"><input type="number" step="0.001" value="${Number(s.kolicina||0)}" data-k="kolicina" style="max-width:120px"/></td>
         <td class="right"><input type="number" step="0.001" value="${Number(s.m1||0)}" data-k="m1" style="max-width:120px"/></td>
+        <td class="right"><input type="number" step="0.001" value="${Number(s.m3||0)}" data-k="m3" style="max-width:120px"/></td>
+        <td class="right"><input type="number" step="1" value="${Number(s.kom||0)}" data-k="kom" style="max-width:120px"/></td>
         <td><input value="${s.napomena||''}" data-k="napomena"/></td>
         <td class="right"><button class="danger" data-del="${i}" style="width:auto">Ukloni</button></td>`;
       tb.appendChild(tr);
@@ -1058,14 +1083,14 @@ function openEditModal(nalog){
     const tr = inp.closest('tr');
     const idx = Array.from(tb.children).indexOf(tr);
     const key = inp.getAttribute('data-k');
-    if(idx>=0 && key){ nalog.stavke[idx][key] = (key==='kolicina' || key==='m1') ? Number(inp.value||0) : inp.value; }
+    if(idx>=0 && key){ nalog.stavke[idx][key] = (key==='kolicina' || key==='m1' || key==='m3' || key==='kom') ? Number(inp.value||0) : inp.value; }
   });
   tb.addEventListener('click', (ev)=>{
     const del = ev.target.getAttribute && ev.target.getAttribute('data-del');
     if(del!=null){ nalog.stavke.splice(Number(del),1); renderLines(); }
   });
   modal.querySelector('#addLine').addEventListener('click', ()=>{
-    (nalog.stavke = nalog.stavke||[]).push({sifra:'',dimenzije:'',jedinica:'',kolicina:0,m1:0,napomena:''});
+    (nalog.stavke = nalog.stavke||[]).push({sifra:'',dimenzije:'',jedinica:'',kolicina:0,m1:0,m3:0,kom:0,napomena:''});
     renderLines();
   });
 


### PR DESCRIPTION
## Summary
- Rename existing quantity to `Količina (M²)` and `Količina (M¹)`
- Add new inputs `Količina (M³)` and `Količina (kom)` with responsive layout
- Extend item tables, modal dialogs and logic to handle new quantity fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0e459b14832791d162aae73a2d3b