### PR TITLE
Display all articles per order in pregled table

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,13 +601,15 @@ function renderPregled(){
     filtered.forEach(n=>{
       const tr = document.createElement('tr');
       const dt = n.vreme ? new Date(n.vreme) : null;
-      const stavkeTxt = (n.stavke||[]).map(s=> (s.sifra||'') + ' (' + (s.kolicina||'') + ')').join('<br>');
+      const artikliHtml = (n.stavke||[])
+        .map(s => `<div>${s.sifra||''} (${s.kolicina||''})</div>`) 
+        .join('');
       tr.innerHTML = '\
         <td class="nowrap"><b>'+ (n.broj||'') +'</b></td>\
         <td>'+ (n.firma||'') +'</td>\
         <td>'+ (n.adresa||'') +'</td>\
         <td class="nowrap">'+ (dt ? dt.toLocaleString() : '') +'</td>\
-        <td>'+ stavkeTxt +'</td>\
+        <td>'+ artikliHtml +'</td>\
         <td class="right">'+ ((n.stavke||[]).length) +'</td>\
         <td class="right"><button class="secondary" data-open="'+ (n.broj||'') +'" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>';
       tb.appendChild(tr);
@@ -625,13 +627,15 @@ function renderPregled(){
         filtered.sort(_sorter.current);
         filtered.forEach(n=>{
           const tr = document.createElement('tr');
-          const stavkeTxt = (n.stavke||[]).map(s=> (s.sifra||'') + ' (' + (s.kolicina||'') + ')').join('<br>');
+          const artikliHtml = (n.stavke||[])
+            .map(s => `<div>${s.sifra||''} (${s.kolicina||''})</div>`)
+            .join('');
           tr.innerHTML = '\
             <td class="nowrap"><b>'+ n.broj +'</b></td>\
             <td>'+ (n.firma||'') +'</td>\
             <td>'+ (n.adresa||'') +'</td>\
             <td class="nowrap">'+ new Date(n.vreme).toLocaleString() +'</td>\
-            <td>'+ stavkeTxt +'</td>\
+            <td>'+ artikliHtml +'</td>\
             <td class="right">'+ ((n.stavke||[]).length) +'</td>\
             <td class="right"><button class="secondary" data-open="'+ n.broj +'" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>';
           tb.appendChild(tr);


### PR DESCRIPTION
## Summary
- render each order's items on separate lines in pregled table

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0ec087608327b143c89127fb46fc