### PR TITLE
Add autocomplete for sifra field in edit modal

### DIFF
--- a/dnevna-proizvodnja.html
+++ b/dnevna-proizvodnja.html
@@ -168,7 +168,7 @@
 
 /* === Artikal autocomplete (custom dropdown) === */
 .ac2-wrap{position:relative}
-#acArtikal{
+#acArtikal, .ac2-menu{
   position:absolute; left:0; right:0; top:100%; margin-top:6px;
   background:#070b1a; border:1px solid #182246; border-radius:12px;
   box-shadow:0 18px 60px rgba(0,0,0,.6);
@@ -276,7 +276,7 @@
     <label for="artikal">Artikal (iz Excela)</label>
     <div class="ac2-wrap">
       <input type="text" id="artikal" name="artikal" placeholder="Počni da kucaš...">
-      <div id="acArtikal"></div>
+      <div id="acArtikal" class="ac2-menu"></div>
     </div>
   </div>
   <div class="field">
@@ -679,23 +679,24 @@ window.APP_PAGES = [
   }
   function norm(s){ return (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').replace(/đ/g,'d').replace(/ž/g,'z').replace(/č/g,'c').replace(/ć/g,'c').replace(/š/g,'s'); }
 
-  function attach(){ 
-    const inp = document.getElementById('artikal');
-    const menu = document.getElementById('acArtikal');
+  function setupArtikalAC(inp){
+    const wrap = inp && inp.closest('.ac2-wrap');
+    const menu = wrap && wrap.querySelector('.ac2-menu');
     if(!inp || !menu) return;
 
     let items=[], idx=-1;
     function hide(){ menu.style.display='none'; menu.innerHTML=''; items=[]; idx=-1; }
-    function choose(i){ 
+    function choose(i){
       const a = items[i]; if(!a) return;
       inp.value = `${a.sifra} – ${a.dimenzije||''} ${a.jedinica?`(${a.jedinica})`:''}`.trim();
       hide();
-      document.getElementById('m1')?.focus();
+      if(inp.id==='artikal') document.getElementById('m1')?.focus();
+      if(inp.id==='editArtikal') document.getElementById('editM1')?.focus();
     }
-    function show(list){ 
+    function show(list){
       menu.innerHTML='';
       items = list.slice(0,30);
-      items.forEach((a,i)=>{ 
+      items.forEach((a,i)=>{
         const d=document.createElement('div'); d.className='ac2-item'+(i===0?' active':'');
         if(i===0) idx=0;
         const main=document.createElement('div'); main.className='ac2-main';
@@ -709,7 +710,7 @@ window.APP_PAGES = [
       });
       menu.style.display = items.length ? 'block' : 'none';
     }
-    function update(q){ 
+    function update(q){
       const n=norm(q||''); if(!n){ hide(); return; }
       const list=(ARTIKLI||[]).filter(a=> norm(`${a.sifra||''} ${a.dimenzije||''} ${a.jedinica||''}`).includes(n));
       list.length ? show(list) : hide();
@@ -717,8 +718,8 @@ window.APP_PAGES = [
     inp.setAttribute('autocomplete','off');
     inp.addEventListener('input', e=> update(e.target.value));
     inp.addEventListener('focus', e=> update(e.target.value));
-    document.addEventListener('click', e=>{ if(e.target!==inp && !menu.contains(e.target)) hide(); });
-    inp.addEventListener('keydown', e=>{ 
+    document.addEventListener('click', e=>{ if(e.target!==inp && !wrap.contains(e.target)) hide(); });
+    inp.addEventListener('keydown', e=>{
       if(menu.style.display!=='block') return;
       const nodes=[...menu.querySelectorAll('.ac2-item')]; if(!nodes.length) return;
       if(e.key==='ArrowDown'){ e.preventDefault(); idx=(idx+1)%nodes.length; nodes.forEach((n,i)=>n.classList.toggle('active', i===idx)); }
@@ -731,9 +732,12 @@ window.APP_PAGES = [
     if(inp.value) update(inp.value);
   }
 
-  document.addEventListener('DOMContentLoaded', async () => { 
+  document.addEventListener('DOMContentLoaded', async () => {
     await loadExcel();
-    attach();
+    const mainInp = document.getElementById('artikal');
+    if(mainInp) setupArtikalAC(mainInp);
+    const editInp = document.getElementById('editArtikal');
+    if(editInp) setupArtikalAC(editInp);
   });
 })();
 // === END Artikal
@@ -1018,7 +1022,7 @@ async function renderPregledCSV(){
     <div class="deck" style="margin-top:8px">
       <div class="col-4"><label>Datum</label><input id="editDatum"/></div>
       <div class="col-4"><label>Broj zahteva</label><input id="editBroj"/></div>
-      <div class="col-4"><label>Artikal</label><input id="editArtikal"/></div>
+      <div class="col-4"><label>Artikal</label><div class="ac2-wrap"><input id="editArtikal"/><div class="ac2-menu"></div></div></div>
       <div class="col-3"><label>M¹</label><input id="editM1" type="number" step="any"/></div>
       <div class="col-3"><label>M²</label><input id="editM2" type="number" step="any"/></div>
       <div class="col-3"><label>M³</label><input id="editM3" type="number" step="any"/></div>

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
 
 /* === Artikal autocomplete (custom dropdown) === */
 .ac2-wrap{position:relative}
-#acArtikal{
+#acArtikal, .ac2-menu{
   position:absolute; left:0; right:0; top:100%; margin-top:6px;
   background:#070b1a; border:1px solid #182246; border-radius:12px;
   box-shadow:0 18px 60px rgba(0,0,0,.6);
@@ -1063,12 +1063,69 @@ function openEditModal(nalog){
   back.style.display = 'flex';
   const tb = modal.querySelector('#detTabela tbody');
 
+  function setupSifraAC(inp){
+    const wrap = inp.closest('.ac2-wrap');
+    const menu = wrap.querySelector('.ac2-menu');
+    let items=[], idx=-1;
+    function hide(){ menu.style.display='none'; menu.innerHTML=''; items=[]; idx=-1; }
+    function choose(i){
+      const a = items[i]; if(!a) return;
+      inp.value = a.sifra || ''; inp.dispatchEvent(new Event('input'));
+      const tr = inp.closest('tr');
+      if(tr){
+        const d = tr.querySelector('input[data-k="dimenzije"]');
+        const j = tr.querySelector('input[data-k="jedinica"]');
+        if(d){ d.value = a.dimenzije || ''; d.dispatchEvent(new Event('input')); }
+        if(j){ j.value = a.jedinica || ''; j.dispatchEvent(new Event('input')); }
+      }
+      hide();
+    }
+    function show(list){
+      menu.innerHTML='';
+      items = list.slice(0,20);
+      items.forEach((a,i)=>{
+        const div=document.createElement('div');
+        div.className='ac2-item'+(i===0?' active':'');
+        if(i===0) idx=0;
+        const main=document.createElement('div'); main.className='ac2-main';
+        const t=document.createElement('div'); t.className='ac2-title'; t.textContent=a.sifra||'';
+        const s=document.createElement('div'); s.className='ac2-sub'; s.textContent=a.dimenzije||'';
+        main.append(t); main.append(s);
+        const u=document.createElement('div'); u.className='ac2-unit'; u.textContent=a.jedinica||'';
+        div.append(main); div.append(u);
+        div.addEventListener('click', ()=> choose(i));
+        menu.append(div);
+      });
+      menu.style.display = items.length ? 'block' : 'none';
+    }
+    function update(q){
+      const nq = normTxt(q||''); if(!nq){ hide(); return; }
+      const list = (ARTIKLI||[]).filter(a=>{
+        const hay = `${a.sifra||''} ${a.dimenzije||''}`;
+        return normTxt(hay).includes(nq);
+      });
+      list.length ? show(list) : hide();
+    }
+    inp.setAttribute('autocomplete','off');
+    inp.addEventListener('input', e=> update(e.target.value));
+    inp.addEventListener('focus', e=> update(e.target.value));
+    inp.addEventListener('keydown', e=>{
+      if(menu.style.display!=='block') return;
+      const nodes=[...menu.querySelectorAll('.ac2-item')]; if(!nodes.length) return;
+      if(e.key==='ArrowDown'){ e.preventDefault(); idx=(idx+1)%nodes.length; nodes.forEach((n,i)=>n.classList.toggle('active', i===idx)); }
+      if(e.key==='ArrowUp'){ e.preventDefault(); idx=(idx-1+nodes.length)%nodes.length; nodes.forEach((n,i)=>n.classList.toggle('active', i===idx)); }
+      if(e.key==='Enter'){ e.preventDefault(); if(idx>=0) choose(idx); }
+      if(e.key==='Escape'){ hide(); }
+    });
+    document.addEventListener('click', e=>{ if(e.target!==inp && !wrap.contains(e.target)) hide(); });
+  }
+
   function renderLines(){
     tb.innerHTML='';
     (nalog.stavke||[]).forEach((s,i)=>{
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td><input value="${s.sifra||''}" data-k="sifra"/></td>
+        <td><div class="ac2-wrap"><input value="${s.sifra||''}" data-k="sifra"/><div class="ac2-menu"></div></div></td>
         <td><input value="${s.dimenzije||''}" data-k="dimenzije"/></td>
         <td><input value="${s.jedinica||''}" data-k="jedinica" style="max-width:80px"/></td>
         <td class="right"><input type="number" step="0.001" value="${Number(s.kolicina||0)}" data-k="kolicina" style="max-width:120px"/></td>
@@ -1078,6 +1135,8 @@ function openEditModal(nalog){
         <td><input value="${s.napomena||''}" data-k="napomena"/></td>
         <td class="right"><button class="danger" data-del="${i}" style="width:auto">Ukloni</button></td>`;
       tb.appendChild(tr);
+      const sinp = tr.querySelector('input[data-k="sifra"]');
+      if(sinp) setupSifraAC(sinp);
     });
   }
   renderLines();


### PR DESCRIPTION
## Summary
- extend autocomplete styles to reusable `.ac2-menu`
- add autocomplete for `sifra` inputs in edit modal, populating related fields
- enable autocomplete for `artikal` in daily production review edits

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l index.html`
- `php -l dnevna-proizvodnja.html`


------
https://chatgpt.com/codex/tasks/task_e_68ba10ecd8bc832780f957e966d5ecb6