### PR TITLE
Handle production report edits without duplicating CSV rows

### DIFF
--- a/save_izvestaj.php
+++ b/save_izvestaj.php
@@ -32,6 +32,7 @@ if (!is_writable($dir)) {
 }
 
 // Ulazi
+$action     = isset($_POST['action']) ? trim((string)$_POST['action']) : '';
 $datum      = isset($_POST['datum']) ? trim((string)$_POST['datum']) : '';
 $broj       = isset($_POST['brojZahteva']) ? trim((string)$_POST['brojZahteva']) : '';
 $artikal    = isset($_POST['artikal']) ? trim((string)$_POST['artikal']) : '';
@@ -41,6 +42,11 @@ $m3         = isset($_POST['m3']) ? trim((string)$_POST['m3']) : '';
 $kom        = isset($_POST['kom']) ? trim((string)$_POST['kom']) : '';
 $napomena   = isset($_POST['napomena']) ? trim((string)$_POST['napomena']) : '';
 $vremeUnosa = date('c');
+
+// Originalni ključevi (za update)
+$odatum   = isset($_POST['o_datum']) ? trim((string)$_POST['o_datum']) : '';
+$obroj    = isset($_POST['o_brojZahteva']) ? trim((string)$_POST['o_brojZahteva']) : '';
+$oartikal = isset($_POST['o_artikal']) ? trim((string)$_POST['o_artikal']) : '';
 
 if ($datum==='' || $broj==='' || $artikal==='') {
   elog("VALIDATION_FAIL datum=$datum broj=$broj artikal=$artikal");
@@ -53,7 +59,63 @@ $m1 = str_replace(',', '.', $m1);
 $m2 = str_replace(',', '.', $m2);
 $m3 = str_replace(',', '.', $m3);
 $kom = str_replace(',', '.', $kom);
+// === UPDATE MODE ===
+if ($action === 'update') {
+  if($odatum==='' || $obroj==='' || $oartikal===''){
+    elog("UPDATE_KEYS_MISSING odatum=$odatum obroj=$obroj oartikal=$oartikal");
+    http_response_code(400);
+    echo "ERROR: nedostaju originalni ključevi.";
+    exit;
+  }
+  if (!file_exists($csv)){
+    http_response_code(404);
+    echo "ERROR: CSV ne postoji.";
+    exit;
+  }
+  $h = @fopen($csv, 'c+');
+  if(!$h){
+    $err = error_get_last();
+    $m = isset($err['message']) ? $err['message'] : 'fopen failed';
+    elog("OPEN_FAIL: $m");
+    http_response_code(500);
+    echo "ERROR: ne mogu da otvorim CSV.";
+    exit;
+  }
+  if (!@flock($h, LOCK_EX)) { elog("LOCK_FAIL"); }
+  $lines = [];
+  while(($line = fgets($h)) !== false){ $lines[] = rtrim($line, "\r\n"); }
+  if(empty($lines)){ @flock($h, LOCK_UN); @fclose($h); http_response_code(404); echo "ERROR: CSV prazan."; exit; }
+  $header = str_getcsv(array_shift($lines), ';');
+  $rows = [];
+  foreach($lines as $ln){ if($ln==='') continue; $rows[] = str_getcsv($ln, ';'); }
+  $updated = false;
+  foreach($rows as &$cols){
+    if(($cols[0]??'')===$odatum && ($cols[1]??'')===$obroj && ($cols[2]??'')===$oartikal){
+      $cols = [$datum, $broj, $artikal, $m1, $m2, $m3, $kom, $napomena, $vremeUnosa];
+      $updated = true;
+      break;
+    }
+  }
+  if(!$updated){
+    @flock($h, LOCK_UN);
+    @fclose($h);
+    http_response_code(404);
+    echo "ERROR: red nije pronađen.";
+    exit;
+  }
+  ftruncate($h, 0);
+  rewind($h);
+  fputcsv($h, $header, ';');
+  foreach($rows as $r){ fputcsv($h, $r, ';'); }
+  @flock($h, LOCK_UN);
+  @fclose($h);
+  @chmod($csv, 0664);
+  elog("UPDATED $odatum|$obroj|$oartikal -> $datum|$broj|$artikal");
+  echo "OK izmenjeno";
+  exit;
+}
 
+// === INSERT MODE (default) ===
 $needHeader = !file_exists($csv) || filesize($csv)===0;
 
 $h = @fopen($csv, 'a');


### PR DESCRIPTION
## Summary
- Support `action=update` in `save_izvestaj.php` to replace existing rows rather than append
- Use original keys to locate and rewrite the matching CSV entry and log the change

## Testing
- `php -l save_izvestaj.php`


------
https://chatgpt.com/codex/tasks/task_e_68c8216dbf3c832780f7038a659bb8bb