### PR TITLE
Adjust qty column alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
     .line-item:last-child{border-bottom:none}
     .right .line-item{text-align:right}
     .qty-col{min-width:80px;text-align:right;font-variant-numeric:tabular-nums;}
-    .qty-col .line-item{display:flex;justify-content:flex-end;text-align:right;font-variant-numeric:inherit;}
+    .qty-col .line-item{display:block;width:100%;text-align:right;font-variant-numeric:inherit;}
 
     /* STATS */
     .stat{ background: var(--glass-strong); border:1px solid var(--line); border-radius:16px; padding:14px; }


### PR DESCRIPTION
## Summary
- ensure `.qty-col .line-item` entries use block layout to keep numeric values right-aligned across columns

## Testing
- visual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68c95cd55e308327a9b9def8bfcbb171