### PR TITLE
Prikaz stanja proizvodnje u pregledu naloga

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,19 +568,18 @@
     }
 
     // Pregled
-    
-function renderPregled(){
+
+let _renderPregledSeq = 0;
+async function renderPregled(){
   const tb = document.querySelector('#pregledTable tbody');
   if(!tb) return;
+  const seq = ++_renderPregledSeq;
   tb.innerHTML='';
   const filterEl = document.querySelector('#filterInput');
   const filter = (filterEl && filterEl.value ? filterEl.value : '').toLowerCase();
 
-  const tryFetch = (url) => fetch(url + (url.includes('?')?'&':'?') + 'ts=' + Date.now(), {cache:'no-store'})
-    .then(r=>{ if(!r.ok) throw new Error('HTTP '+r.status); return r.text(); });
-
   function parseCSV(text){
-    text = text.replace(/^\uFEFF/, '');
+    text = (text||'').replace(/^\uFEFF/, '');
     const first = text.split(/\r?\n/,1)[0] || '';
     const delim = first.includes(';') ? ';' : ',';
     const rows = [];
@@ -606,13 +605,104 @@ function renderPregled(){
     return rows;
   }
 
-  function normalizeHeader(h){
-    return (h||'').toString().trim().toLowerCase();
+  const normalizeHeader = (h)=> (h||'').toString().trim().toLowerCase();
+
+  const toNum = (value)=>{
+    if(value===undefined || value===null) return null;
+    if(typeof value === 'number') return Number.isFinite(value) ? value : null;
+    if(typeof value === 'string'){
+      const trimmed = value.trim();
+      if(!trimmed) return null;
+      const num = Number(trimmed);
+      return Number.isFinite(num) ? num : null;
+    }
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  };
+
+  const toProdNumber = (value)=>{
+    if(value===undefined || value===null) return 0;
+    if(typeof value === 'number') return Number.isFinite(value) ? value : 0;
+    const str = String(value).trim();
+    if(!str) return 0;
+    const num = Number(str.replace(/\s+/g,'').replace(',','.'));
+    return Number.isFinite(num) ? num : 0;
+  };
+
+  const normalizeUnit = (unit)=>{
+    const raw = (unit||'').toString().trim().toLowerCase()
+      .replace(/¹/g,'1').replace(/²/g,'2').replace(/³/g,'3')
+      .replace(/\./g,'').replace(/\s+/g,'');
+    if(raw==='komada' || raw==='komad') return 'kom';
+    return raw;
+  };
+
+  const normalizeOrderNo = (no)=>{
+    const raw = (no||'').toString().trim();
+    if(!raw) return '';
+    const normalized = raw.replace(/^0+(?=\d)/,'');
+    if(!normalized) return raw.includes('0') ? '0' : raw;
+    return normalized;
+  };
+
+  const cleanArt = (art)=> (art||'').toString().trim().toLowerCase();
+  const makeProdKey = (broj, art)=> `${broj}||${art}`;
+  const buildOrderKeys = (broj)=>{
+    const raw = (broj||'').toString().trim();
+    const set = new Set();
+    if(raw) set.add(raw);
+    const normalized = normalizeOrderNo(raw);
+    if(normalized) set.add(normalized);
+    if(normalized){
+      const padLen = (raw && raw.length>normalized.length) ? raw.length : 4;
+      set.add(normalized.padStart(padLen, '0'));
+    }
+    return Array.from(set).filter(Boolean);
+  };
+
+  const addProductionTotals = (map, broj, art, delta)=>{
+    const artKey = cleanArt(art);
+    if(!artKey) return;
+    const keys = buildOrderKeys(broj);
+    if(!keys.length) return;
+    keys.forEach(k=>{
+      const key = makeProdKey(k, artKey);
+      const rec = map.get(key);
+      if(rec){
+        rec.m1 += delta.m1;
+        rec.m2 += delta.m2;
+        rec.m3 += delta.m3;
+        rec.kom += delta.kom;
+      }else{
+        map.set(key, {m1:delta.m1, m2:delta.m2, m3:delta.m3, kom:delta.kom});
+      }
+    });
+  };
+
+  const lookupProduction = (map, broj, art)=>{
+    const artKey = cleanArt(art);
+    if(!artKey) return null;
+    const keys = buildOrderKeys(broj);
+    for(const key of keys){
+      const rec = map.get(makeProdKey(key, artKey));
+      if(rec) return rec;
+    }
+    return null;
+  };
+
+  function formatPair(ordered, produced, decimals){
+    const ordVal = toNum(ordered);
+    if(ordVal===null) return '';
+    const prodValRaw = toNum(produced);
+    const prodVal = prodValRaw===null ? 0 : prodValRaw;
+    return `${ordVal.toFixed(decimals)}/${prodVal.toFixed(decimals)}`;
   }
 
-  function renderFromText(text){
-    const rows = parseCSV(text.trim());
-    if(!rows.length) return;
+  function parseOrdersFromText(text){
+    text = (text||'').replace(/^\uFEFF/, '').trim();
+    if(!text) return [];
+    const rows = parseCSV(text);
+    if(!rows.length) return [];
     const header = rows[0].map(normalizeHeader);
     const idx = (name)=> header.indexOf(normalizeHeader(name));
     const iBroj   = idx('broj')>=0 ? idx('broj') : 0;
@@ -621,105 +711,152 @@ function renderPregled(){
     const iVreme  = idx('vreme');
     const iStavke = (idx('stavke_json') >= 0) ? idx('stavke_json') : idx('stavke');
 
-    const orders = rows.slice(1).map(cols=>{
-      let stavke=[];
+    const orders = [];
+    for(let i=1;i<rows.length;i++){
+      const cols = rows[i];
+      if(!cols || !cols.length) continue;
+      const broj = (cols[iBroj]||'').trim();
+      if(!broj) continue;
+      const firma  = iFirma>=0  ? (cols[iFirma]||'').trim()  : '';
+      const adresa = iAdresa>=0 ? (cols[iAdresa]||'').trim() : '';
+      const vreme  = iVreme>=0  ? (cols[iVreme]||'').trim()  : '';
+      let stavke = [];
       const rawStavke = iStavke>=0 ? (cols[iStavke]||'') : '';
-      if(rawStavke){ try{ stavke = JSON.parse(rawStavke); }catch(_){ stavke=[]; } }
-      return {
-        broj:   (cols[iBroj]||'').trim(),
-        firma:  iFirma>=0  ? (cols[iFirma]||'').trim()  : '',
-        adresa: iAdresa>=0 ? (cols[iAdresa]||'').trim() : '',
-        vreme:  iVreme>=0  ? (cols[iVreme]||'').trim()  : '',
-        stavke
-      };
-    }).filter(n=>n.broj);
-
-    window._ORDERS_CACHE = orders.slice();
-
-    const filtered = orders.filter(n => !filter || [n.broj, n.firma, n.adresa].join(' ').toLowerCase().includes(filter));
-    filtered.sort(_sorter.current);
-
-      filtered.forEach(n=>{
-        const tr = document.createElement('tr');
-        const dt = n.vreme ? new Date(n.vreme) : null;
-        const fmt = (v,d=2)=>{
-          if(v===undefined || v===null) return '';
-          if(typeof v === 'string' && v.trim()==='') return '';
-          const num = Number(v);
-          if(Number.isNaN(num)) return '';
-          return num.toFixed(d);
-        };
-        const artikliHtml = [];
-        const m1Html = [], m2Html = [], m3Html = [], komHtml = [];
-        (n.stavke||[]).forEach(s=>{
-          const unit = (s.jedinica||'').toLowerCase();
-          artikliHtml.push(`<div class="line-item">${s.sifra||''}</div>`);
-          m1Html.push(`<div class="line-item">${fmt(unit==='m1'||unit==='m¹'?s.kolicina:s.m1)}</div>`);
-          m2Html.push(`<div class="line-item">${fmt(unit==='m2'||unit==='m²'||!['m1','m3','kom'].includes(unit)?s.kolicina:s.m2)}</div>`);
-          m3Html.push(`<div class="line-item">${fmt(unit==='m3'||unit==='m³'?s.kolicina:s.m3,3)}</div>`);
-          komHtml.push(`<div class="line-item">${fmt(unit==='kom'?s.kolicina:s.kom,0)}</div>`);
-        });
-        tr.innerHTML = `
-          <td class="nowrap"><b>${n.broj||''}</b></td>
-          <td>${n.firma||''}</td>
-          <td>${n.adresa||''}</td>
-          <td class="nowrap">${dt ? dt.toLocaleString() : ''}</td>
-          <td>${artikliHtml.join('')}</td>
-          <td class="right qty-col">${m1Html.join('')}</td>
-          <td class="right qty-col">${m2Html.join('')}</td>
-          <td class="right qty-col">${m3Html.join('')}</td>
-          <td class="right qty-col">${komHtml.join('')}</td>
-          <td class="right">${(n.stavke||[]).length}</td>
-          <td class="right"><button class="secondary" data-open="${n.broj||''}" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>`;
-        tb.appendChild(tr);
-      });
+      if(rawStavke){
+        try{
+          const parsed = JSON.parse(rawStavke);
+          if(Array.isArray(parsed)) stavke = parsed;
+        }catch(err){
+          try{
+            const fixed = rawStavke.replace(/""/g,'"');
+            const parsed = JSON.parse(fixed);
+            if(Array.isArray(parsed)) stavke = parsed;
+          }catch(_){ stavke = []; }
+        }
+      }
+      orders.push({ broj, firma, adresa, vreme, stavke });
+    }
+    return orders;
   }
 
-  // Try relative and absolute CSV
-  tryFetch('data/zahtevi.csv')
-    .then(renderFromText)
-    .catch(()=> tryFetch('/data/zahtevi.csv').then(renderFromText).catch(()=>{
-      // Final fallback: localStorage
+  function parseProduction(text){
+    text = (text||'').replace(/^\uFEFF/, '').trim();
+    if(!text) return new Map();
+    const rows = parseCSV(text);
+    if(rows.length<=1) return new Map();
+    const header = rows[0].map(normalizeHeader);
+    const idx = (name)=> header.indexOf(normalizeHeader(name));
+    const iBroj = idx('brojzahteva');
+    const iArt  = idx('artikal');
+    const iM1   = idx('m1');
+    const iM2   = idx('m2');
+    const iM3   = idx('m3');
+    const iKom  = idx('kom');
+    const map = new Map();
+    for(let i=1;i<rows.length;i++){
+      const cols = rows[i];
+      if(!cols || !cols.length) continue;
+      const broj = ((iBroj>=0 ? cols[iBroj] : (cols[1]||cols[0]||''))||'').trim();
+      const art  = ((iArt>=0  ? cols[iArt]  : (cols[2]||''))||'').trim();
+      if(!broj || !art) continue;
+      const delta = {
+        m1: toProdNumber(iM1>=0 ? cols[iM1] : null),
+        m2: toProdNumber(iM2>=0 ? cols[iM2] : null),
+        m3: toProdNumber(iM3>=0 ? cols[iM3] : null),
+        kom: toProdNumber(iKom>=0 ? cols[iKom] : null)
+      };
+      addProductionTotals(map, broj, art, delta);
+    }
+    return map;
+  }
+
+  async function fetchOrders(){
+    const urls = ['data/zahtevi.csv','/data/zahtevi.csv'];
+    for(const url of urls){
       try{
-        const orders = JSON.parse(localStorage.getItem('proizvodnja_nalozi_v1')||'[]')||[];
-        window._ORDERS_CACHE = orders.slice();
-        const filtered = orders.filter(n => !filter || [n.broj, n.firma, n.adresa].join(' ').toLowerCase().includes(filter));
-        filtered.sort(_sorter.current);
-          filtered.forEach(n=>{
-            const tr = document.createElement('tr');
-            const fmt = (v,d=2)=>{
-              if(v===undefined || v===null) return '';
-              if(typeof v === 'string' && v.trim()==='') return '';
-              const num = Number(v);
-              if(Number.isNaN(num)) return '';
-              return num.toFixed(d);
-            };
-            const artikliHtml = [];
-            const m1Html = [], m2Html = [], m3Html = [], komHtml = [];
-            (n.stavke||[]).forEach(s=>{
-              const unit = (s.jedinica||'').toLowerCase();
-              artikliHtml.push(`<div class="line-item">${s.sifra||''}</div>`);
-              m1Html.push(`<div class="line-item">${fmt(unit==='m1'||unit==='m¹'?s.kolicina:s.m1)}</div>`);
-              m2Html.push(`<div class="line-item">${fmt(unit==='m2'||unit==='m²'||!['m1','m3','kom'].includes(unit)?s.kolicina:s.m2)}</div>`);
-              m3Html.push(`<div class="line-item">${fmt(unit==='m3'||unit==='m³'?s.kolicina:s.m3,3)}</div>`);
-              komHtml.push(`<div class="line-item">${fmt(unit==='kom'?s.kolicina:s.kom,0)}</div>`);
-            });
-            tr.innerHTML = `
-              <td class="nowrap"><b>${n.broj}</b></td>
-              <td>${n.firma||''}</td>
-              <td>${n.adresa||''}</td>
-              <td class="nowrap">${new Date(n.vreme).toLocaleString()}</td>
-              <td>${artikliHtml.join('')}</td>
-              <td class="right qty-col">${m1Html.join('')}</td>
-              <td class="right qty-col">${m2Html.join('')}</td>
-              <td class="right qty-col">${m3Html.join('')}</td>
-              <td class="right qty-col">${komHtml.join('')}</td>
-              <td class="right">${(n.stavke||[]).length}</td>
-              <td class="right"><button class="secondary" data-open="${n.broj}" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>`;
-            tb.appendChild(tr);
-          });
-      }catch(_){}
-    }));
+        const res = await fetch(url + (url.includes('?')?'&':'?') + 'ts=' + Date.now(), {cache:'no-store'});
+        if(!res.ok) throw new Error('HTTP '+res.status);
+        const text = await res.text();
+        return parseOrdersFromText(text);
+      }catch(_){ }
+    }
+    try{
+      const local = JSON.parse(localStorage.getItem('proizvodnja_nalozi_v1')||'[]');
+      return Array.isArray(local) ? local : [];
+    }catch(_){ return []; }
+  }
+
+  async function fetchProduction(){
+    const urls = ['data/proizvodnja.csv','/data/proizvodnja.csv'];
+    for(const url of urls){
+      try{
+        const res = await fetch(url + (url.includes('?')?'&':'?') + 'ts=' + Date.now(), {cache:'no-store'});
+        if(!res.ok) throw new Error('HTTP '+res.status);
+        const text = await res.text();
+        return parseProduction(text);
+      }catch(_){ }
+    }
+    return new Map();
+  }
+
+  const [orders, productionTotals] = await Promise.all([fetchOrders(), fetchProduction()]);
+  if(seq !== _renderPregledSeq) return;
+
+  window._ORDERS_CACHE = Array.isArray(orders) ? orders.slice() : [];
+
+  const filtered = (orders||[]).filter(n => {
+    const hay = [n.broj, n.firma, n.adresa].map(v=> (v||'').toString().toLowerCase()).join(' ');
+    return !filter || hay.includes(filter);
+  });
+  filtered.sort(_sorter.current);
+
+  filtered.forEach(n=>{
+    const tr = document.createElement('tr');
+    const dt = n.vreme ? new Date(n.vreme) : null;
+    const items = Array.isArray(n.stavke) ? n.stavke : [];
+    const artikliHtml = [];
+    const m1Html = [], m2Html = [], m3Html = [], komHtml = [];
+    items.forEach(s=>{
+      if(!s) return;
+      const sifra = (s.sifra||'').toString().trim();
+      const unit = normalizeUnit(s.jedinica);
+      const prod = lookupProduction(productionTotals, n.broj, sifra);
+      const isM1 = unit==='m1';
+      const isM3 = unit==='m3';
+      const isKom = unit==='kom';
+      const useBaseForM2 = unit==='m2' || (!isM1 && !isM3 && !isKom);
+
+      const orderedM1 = isM1 ? toNum(s.kolicina) : toNum(s.m1);
+      const orderedM2 = useBaseForM2 ? toNum(s.kolicina) : toNum(s.m2);
+      const orderedM3 = isM3 ? toNum(s.kolicina) : toNum(s.m3);
+      const orderedKom = isKom ? toNum(s.kolicina) : toNum(s.kom);
+
+      const producedM1 = prod ? prod.m1 : null;
+      const producedM2 = prod ? prod.m2 : null;
+      const producedM3 = prod ? prod.m3 : null;
+      const producedKom = prod ? prod.kom : null;
+
+      artikliHtml.push(`<div class="line-item">${sifra||''}</div>`);
+      m1Html.push(`<div class="line-item">${formatPair(orderedM1, producedM1, 2)}</div>`);
+      m2Html.push(`<div class="line-item">${formatPair(orderedM2, producedM2, 2)}</div>`);
+      m3Html.push(`<div class="line-item">${formatPair(orderedM3, producedM3, 3)}</div>`);
+      komHtml.push(`<div class="line-item">${formatPair(orderedKom, producedKom, 0)}</div>`);
+    });
+
+    tr.innerHTML = `
+      <td class="nowrap"><b>${n.broj||''}</b></td>
+      <td>${n.firma||''}</td>
+      <td>${n.adresa||''}</td>
+      <td class="nowrap">${dt ? dt.toLocaleString() : ''}</td>
+      <td>${artikliHtml.join('')}</td>
+      <td class="right qty-col">${m1Html.join('')}</td>
+      <td class="right qty-col">${m2Html.join('')}</td>
+      <td class="right qty-col">${m3Html.join('')}</td>
+      <td class="right qty-col">${komHtml.join('')}</td>
+      <td class="right">${items.length}</td>
+      <td class="right"><button class="secondary" data-open="${n.broj||''}" style="width:auto">Otvori</button> <button class="ok edit-btn" style="width:auto;margin-left:6px">Izmeni</button></td>`;
+    tb.appendChild(tr);
+  });
 }
 
 
@@ -1261,7 +1398,7 @@ function saveEditedNalog(nalog){
       setLastNo(getLastNo());
       await loadExcel();
       updateStats();
-      renderPregled();
+      await renderPregled();
       rebuildCompaniesFromOrders();
     })();
   </script>


### PR DESCRIPTION
## Summary
- povezao pregled naloga sa dnevnom proizvodnjom i sabrao učinke po nalogu i artiklu
- formatirao prikaz količina kao poručeno/proizvedeno u svim kolonama pregleda
- osvežio inicijalno učitavanje da sačeka asinhrono renderovanje pregleda

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c96970129c8327b9f1b1c798a99f7b