### PR TITLE
Adjust production parsing and refresh handling

### DIFF
--- a/dnevna-proizvodnja.html
+++ b/dnevna-proizvodnja.html
@@ -898,6 +898,30 @@ document.addEventListener("DOMContentLoaded", function(){
 
 <script>
 (function(){
+  const sink = document.getElementById('serverSink');
+  if(!sink || sink.__refreshPregledAttached) return;
+  sink.__refreshPregledAttached = true;
+  sink.addEventListener('load', async () => {
+    try{
+      if(typeof window.renderPregled === 'function'){
+        const r = window.renderPregled();
+        if(r && typeof r.then === 'function') await r;
+      }else if(typeof window.renderPregledCSV === 'function'){
+        const r = window.renderPregledCSV();
+        if(r && typeof r.then === 'function') await r;
+      }else{
+        window.location.reload();
+      }
+    }catch(err){
+      console.warn('Greška pri osvežavanju pregleda proizvodnje', err);
+    }
+  });
+})();
+</script>
+
+
+<script>
+(function(){
   const q = s => document.querySelector(s);
   function setTab(which){
   const actions = document.getElementById("unosActions");

--- a/index.html
+++ b/index.html
@@ -745,9 +745,18 @@ async function renderPregled(){
     const rows = parseCSV(text);
     if(rows.length<=1) return new Map();
     const header = rows[0].map(normalizeHeader);
-    const idx = (name)=> header.indexOf(normalizeHeader(name));
-    const iBroj = idx('brojzahteva');
-    const iArt  = idx('artikal');
+    const idx = (name)=>{
+      if(Array.isArray(name)){
+        for(const n of name){
+          const i = header.indexOf(normalizeHeader(n));
+          if(i>=0) return i;
+        }
+        return -1;
+      }
+      return header.indexOf(normalizeHeader(name));
+    };
+    const iBroj = idx(['brojzahteva','brojnaloga','broj naloga','broj']);
+    const iArt  = idx(['artikal','sifra']);
     const iM1   = idx('m1');
     const iM2   = idx('m2');
     const iM3   = idx('m3');
@@ -788,14 +797,16 @@ async function renderPregled(){
 
   async function fetchProduction(){
     const urls = ['data/proizvodnja.csv','/data/proizvodnja.csv'];
+    let lastError = null;
     for(const url of urls){
       try{
         const res = await fetch(url + (url.includes('?')?'&':'?') + 'ts=' + Date.now(), {cache:'no-store'});
         if(!res.ok) throw new Error('HTTP '+res.status);
         const text = await res.text();
         return parseProduction(text);
-      }catch(_){ }
+      }catch(err){ lastError = err; }
     }
+    console.warn('Upozorenje: data/proizvodnja.csv nije dostupna.', lastError || '');
     return new Map();
   }
 


### PR DESCRIPTION
## Summary
- allow the production parser to recognise additional column aliases for job numbers and articles
- warn in the console when the production CSV cannot be retrieved
- refresh the production review after saving reports so new data is pulled in automatically

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c974637ffc83278c6a40a2f7bdaa75