### PR TITLE
Add fallback without timestamp for order and production fetches

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,14 +781,27 @@ async function renderPregled(){
 
   async function fetchOrders(){
     const urls = ['data/zahtevi.csv','/data/zahtevi.csv'];
+    let lastError = null;
     for(const url of urls){
+      const bustUrl = url + (url.includes('?')?'&':'?') + 'ts=' + Date.now();
       try{
-        const res = await fetch(url + (url.includes('?')?'&':'?') + 'ts=' + Date.now(), {cache:'no-store'});
+        const res = await fetch(bustUrl, {cache:'no-store'});
         if(!res.ok) throw new Error('HTTP '+res.status);
         const text = await res.text();
         return parseOrdersFromText(text);
-      }catch(_){ }
+      }catch(err){
+        lastError = err;
+        try{
+          const res = await fetch(url, {cache:'no-store'});
+          if(!res.ok) throw new Error('HTTP '+res.status);
+          const text = await res.text();
+          return parseOrdersFromText(text);
+        }catch(innerErr){
+          lastError = innerErr;
+        }
+      }
     }
+    if(lastError) console.warn('Upozorenje: data/zahtevi.csv nije dostupna.', lastError);
     try{
       const local = JSON.parse(localStorage.getItem('proizvodnja_nalozi_v1')||'[]');
       return Array.isArray(local) ? local : [];
@@ -799,12 +812,21 @@ async function renderPregled(){
     const urls = ['data/proizvodnja.csv','/data/proizvodnja.csv'];
     let lastError = null;
     for(const url of urls){
+      const bustUrl = url + (url.includes('?')?'&':'?') + 'ts=' + Date.now();
       try{
-        const res = await fetch(url + (url.includes('?')?'&':'?') + 'ts=' + Date.now(), {cache:'no-store'});
+        const res = await fetch(bustUrl, {cache:'no-store'});
         if(!res.ok) throw new Error('HTTP '+res.status);
         const text = await res.text();
         return parseProduction(text);
-      }catch(err){ lastError = err; }
+      }catch(err){
+        lastError = err;
+        try{
+          const res = await fetch(url, {cache:'no-store'});
+          if(!res.ok) throw new Error('HTTP '+res.status);
+          const text = await res.text();
+          return parseProduction(text);
+        }catch(innerErr){ lastError = innerErr; }
+      }
     }
     console.warn('Upozorenje: data/proizvodnja.csv nije dostupna.', lastError || '');
     return new Map();


### PR DESCRIPTION
## Summary
- add fallback requests without timestamp parameters for both fetchOrders and fetchProduction
- log a warning when the orders CSV cannot be fetched and local storage fallback is used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c99c9aa0048327a9fa18171e87781f