### PR TITLE
Adjust CSV fetch fallback order

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,16 +783,16 @@ async function renderPregled(){
     const urls = ['data/zahtevi.csv','/data/zahtevi.csv'];
     let lastError = null;
     for(const url of urls){
-      const bustUrl = url + (url.includes('?')?'&':'?') + 'ts=' + Date.now();
       try{
-        const res = await fetch(bustUrl, {cache:'no-store'});
+        const res = await fetch(url, {cache:'no-store'});
         if(!res.ok) throw new Error('HTTP '+res.status);
         const text = await res.text();
         return parseOrdersFromText(text);
       }catch(err){
         lastError = err;
         try{
-          const res = await fetch(url, {cache:'no-store'});
+          const bustUrl = url + (url.includes('?')?'&':'?') + 'ts=' + Date.now();
+          const res = await fetch(bustUrl, {cache:'no-store'});
           if(!res.ok) throw new Error('HTTP '+res.status);
           const text = await res.text();
           return parseOrdersFromText(text);
@@ -812,16 +812,16 @@ async function renderPregled(){
     const urls = ['data/proizvodnja.csv','/data/proizvodnja.csv'];
     let lastError = null;
     for(const url of urls){
-      const bustUrl = url + (url.includes('?')?'&':'?') + 'ts=' + Date.now();
       try{
-        const res = await fetch(bustUrl, {cache:'no-store'});
+        const res = await fetch(url, {cache:'no-store'});
         if(!res.ok) throw new Error('HTTP '+res.status);
         const text = await res.text();
         return parseProduction(text);
       }catch(err){
         lastError = err;
         try{
-          const res = await fetch(url, {cache:'no-store'});
+          const bustUrl = url + (url.includes('?')?'&':'?') + 'ts=' + Date.now();
+          const res = await fetch(bustUrl, {cache:'no-store'});
           if(!res.ok) throw new Error('HTTP '+res.status);
           const text = await res.text();
           return parseProduction(text);


### PR DESCRIPTION
## Summary
- request CSV feeds without cache-busting parameters first, then fall back to timestamped URLs if needed
- retain the existing console warnings and parsing flows for orders and production data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca99bd99d08327a655397c89a30c6c