### PR TITLE
Add force bust refresh option to pregled data fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
     // Pregled
 
 let _renderPregledSeq = 0;
-async function renderPregled(){
+async function renderPregled(options = {}){
   const tb = document.querySelector('#pregledTable tbody');
   if(!tb){
     ordersReady = true;
@@ -619,6 +619,7 @@ async function renderPregled(){
     return;
   }
   const seq = ++_renderPregledSeq;
+  const { forceBust = false } = options || {};
   tb.innerHTML='';
   const filterEl = document.querySelector('#filterInput');
   const filter = (filterEl && filterEl.value ? filterEl.value : '').toLowerCase();
@@ -824,7 +825,8 @@ async function renderPregled(){
     return map;
   }
 
-  async function fetchOrders(){
+  async function fetchOrders(options = {}){
+    const { forceBust = false } = options || {};
     const urls = ['data/zahtevi.csv','/data/zahtevi.csv'];
     let lastError = null;
     for(const url of urls){
@@ -836,6 +838,7 @@ async function renderPregled(){
         return parseOrdersFromText(text);
       }catch(err){
         lastError = err;
+        if(forceBust) continue;
         try{
           const res = await fetch(url, {cache:'no-store'});
           if(!res.ok) throw new Error('HTTP '+res.status);
@@ -853,7 +856,8 @@ async function renderPregled(){
     }catch(_){ return []; }
   }
 
-  async function fetchProduction(){
+  async function fetchProduction(options = {}){
+    const { forceBust = false } = options || {};
     const urls = ['data/proizvodnja.csv','/data/proizvodnja.csv'];
     let lastError = null;
     for(const url of urls){
@@ -865,6 +869,7 @@ async function renderPregled(){
         return parseProduction(text);
       }catch(err){
         lastError = err;
+        if(forceBust) continue;
         try{
           const res = await fetch(url, {cache:'no-store'});
           if(!res.ok) throw new Error('HTTP '+res.status);
@@ -877,7 +882,10 @@ async function renderPregled(){
     return new Map();
   }
 
-  const [fetchedOrders, productionTotals] = await Promise.all([fetchOrders(), fetchProduction()]);
+  const [fetchedOrders, productionTotals] = await Promise.all([
+    fetchOrders({forceBust}),
+    fetchProduction({forceBust})
+  ]);
   if(seq !== _renderPregledSeq) return;
 
   const localOrders = getOrders();
@@ -1001,7 +1009,7 @@ async function renderPregled(){
     q('#modalBack').addEventListener('click', (e)=>{ if(e.target.id==='modalBack') e.currentTarget.style.display='none'; });
 
     // Tools
-    q('#osveziPregled').addEventListener('click', renderPregled);
+    q('#osveziPregled').addEventListener('click', ()=>renderPregled({forceBust:true}));
     q('#filterInput').addEventListener('input', renderPregled);
     q('#exportCSV').addEventListener('click', exportCSV);
     q('#printBtn').addEventListener('click', ()=>window.print());


### PR DESCRIPTION
## Summary
- allow `renderPregled` to accept an options object and propagate a `forceBust` flag
- update `fetchOrders` and `fetchProduction` to bypass cached fallbacks when the flag is set
- trigger the Osveži refresh control to request uncached data on demand

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa086817c8327820a4e913dddde33