### PR TITLE
Normalize article keys in plan vs proizvodnja view

### DIFF
--- a/dnevna-proizvodnja.html
+++ b/dnevna-proizvodnja.html
@@ -1128,7 +1128,29 @@ function normalizeRequestNumber(v){
   return cleaned || '0';
 }
 function normalizeArticleKey(v){
-  return (v||'').toString().trim().toLowerCase();
+  if(v===null || v===undefined) return '';
+  let str = (v||'').toString().trim();
+  if(!str) return '';
+
+  const unitMatch = str.match(/\s*\(([^)]+)\)\s*$/);
+  if(unitMatch){
+    const maybeUnit = unitMatch[1].trim();
+    if(maybeUnit){
+      const canonical = canonicalUnit(maybeUnit);
+      if(['m1','m2','m3','kom'].includes(canonical)){
+        str = str.slice(0, unitMatch.index).trim();
+      }
+    }
+  }
+
+  str = str.replace(/\s[–—-]\s*.*$/, '').replace(/[–—-]\s*$/, '');
+  if(!str) return '';
+
+  str = str.toLowerCase();
+  str = str.normalize('NFD').replace(/[\u0300-\u036f]/g,'');
+  str = str.replace(/đ/g,'d').replace(/ž/g,'z').replace(/č/g,'c').replace(/ć/g,'c').replace(/š/g,'s');
+
+  return str.trim();
 }
 function parseCSVFlexible(text){
   text = text.replace(/^\uFEFF/, '');


### PR DESCRIPTION
## Summary
- strip autocomplete decorations (dash-separated descriptors and unit suffixes) before normalizing article keys
- allow additional punctuation variants so plan sifra values and proizvodnja article strings collapse to a shared key
- ensure plan vs. realizacija aggregates merge matching plan and production rows for accurate comparisons

## Testing
- python3 -m http.server 8000 (manual)

------
https://chatgpt.com/codex/tasks/task_e_68cb004ca7b083278b2b83b4110500ab